### PR TITLE
Changed MinimumVersion from float to string

### DIFF
--- a/Topaz/TopazDeNoise.download.recipe.yaml
+++ b/Topaz/TopazDeNoise.download.recipe.yaml
@@ -1,7 +1,7 @@
 Comment: Created by MK 2023 05 05
 Description: Downloads the latest version of Topaz DeNoise.
 Identifier: com.github.markkenny.autopkg.download.topaz-denoise
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz DeNoise

--- a/Topaz/TopazDeNoise.pkg.recipe.yaml
+++ b/Topaz/TopazDeNoise.pkg.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Downloads the latest version of Topaz DeNoise and creates a package.
 Identifier: com.github.markkenny.autopkg.pkg.topaz-denoise
 ParentRecipe: com.github.markkenny.autopkg.download.topaz-denoise
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz DeNoise

--- a/Topaz/TopazGigapixel.download.recipe.yaml
+++ b/Topaz/TopazGigapixel.download.recipe.yaml
@@ -1,7 +1,7 @@
 Comment: Created by MK 2023 05 05
 Description: Downloads the latest version of Topaz GigaPixel.
 Identifier: com.github.markkenny.autopkg.download.topaz-gigapixel
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Gigapixel

--- a/Topaz/TopazGigapixel.pkg.recipe.yaml
+++ b/Topaz/TopazGigapixel.pkg.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Downloads the latest version of Topaz Gigapixel and creates a package.
 Identifier: com.github.markkenny.autopkg.pkg.topaz-gigapixel
 ParentRecipe: com.github.markkenny.autopkg.download.topaz-gigapixel
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Gigapixel

--- a/Topaz/TopazPhotoAI.download.recipe.yaml
+++ b/Topaz/TopazPhotoAI.download.recipe.yaml
@@ -1,7 +1,7 @@
 Comment: Created by MK 2023 12 19
 Description: Downloads the latest version of Topaz Photo AI.
 Identifier: com.github.markkenny.autopkg.download.topaz-photo-ai
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Photo AI

--- a/Topaz/TopazPhotoAI.pkg.recipe.yaml
+++ b/Topaz/TopazPhotoAI.pkg.recipe.yaml
@@ -2,7 +2,7 @@ Comment: Created by MK 2023 12 19
 Description: Downloads the latest version of Topaz Photo AI and creates a versionsed package.
 Identifier: com.github.markkenny.autopkg.pkg.topaz-photo-ai
 ParentRecipe: com.github.markkenny.autopkg.download.topaz-photo-ai
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Photo AI

--- a/Topaz/TopazSharpen.download.recipe.yaml
+++ b/Topaz/TopazSharpen.download.recipe.yaml
@@ -1,7 +1,7 @@
 Comment: Created by MK 2023 05 05
 Description: Downloads the latest version of Topaz Sharpen.
 Identifier: com.github.markkenny.autopkg.download.topaz-sharpen
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Sharpen

--- a/Topaz/TopazSharpen.pkg.recipe.yaml
+++ b/Topaz/TopazSharpen.pkg.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Downloads the latest version of Topaz Sharpen and creates a package.
 Identifier: com.github.markkenny.autopkg.pkg.topaz-sharpen
 ParentRecipe: com.github.markkenny.autopkg.download.topaz-sharpen
-MinimumVersion: 2.3
+MinimumVersion: "2.3"
 
 Input:
   NAME: Topaz Sharpen


### PR DESCRIPTION
  Encountered the following errors when attempting to run recipe:

```
Traceback (most recent call last):
  ...snip...
  File "/Library/AutoPkg/autopkglib/__init__.py", line 420, in version_equal_or_greater
    return LooseVersion(this) >= LooseVersion(that)
  ...snip...
  File "/Library/AutoPkg/Python3/...snip.../distutils/version.py", line 314, in parse
    components = [x for x in self.component_re.split(vstring)
TypeError: expected string or bytes-like object
```

  After some debugging noticed that the YAML value for MaximumVersion
  was actually as a float, and the Python LooseVersion() function
  requires a string.

  Placed the MaximumVersion value in double quotes.