### PR TITLE
Fix URLTextSearcher pattern in FrameIOTransfer recipes

### DIFF
--- a/FrameIO/FrameIOTransfer.download.recipe.yaml
+++ b/FrameIO/FrameIOTransfer.download.recipe.yaml
@@ -1,30 +1,21 @@
 Comment: Created by MK 2024 11 26 Struggling
 Description: Downloads the latest Frame IO
 Identifier: com.github.markkenny.autopkg.download.frameiotransfer
-MinimumVersion: 2.3
+MinimumVersion: '2.3'
 
 Input:
   NAME: FrameIO Transfer
-  SEARCH_URL: https://frame.io/transfer
-#  SEARCH_PATTERN: (https://transferapp\.frame\.io/Frame\.io-Transfer/.*?/latest/darwin/x64/Frame.*\.dmg)
-# My SEARCH_PATTERN regex is not good enough, and I can't skip the error!
-# This download recipe doesn't work. See README.md
 
 Process:
-# - Processor: URLTextSearcher
-#   Arguments:
-#     re_pattern: '%SEARCH_PATTERN%'
-#     url: '%SEARCH_URL%'
+- Processor: URLTextSearcher
+  Arguments:
+    re_pattern: 'href="(https://transferapp\.frame\.io/Frame\.io-Transfer/[a-f0-9]+/latest/darwin/x64/Frame\.io\+Transfer\.dmg)"'
+    url: 'https://frame.io/transfer'
 
 - Processor: URLDownloader
   Arguments:
     filename: '%NAME%.dmg'
     url: '%match%'
-
-- Processor: Versioner
-  Arguments:
-    input_plist_path: '%pathname%/Frame.io Transfer.app/Contents/Info.plist'
-    plist_version_key: CFBundleShortVersionString
 
 - Processor: EndOfCheckPhase
 
@@ -32,3 +23,8 @@ Process:
   Arguments:
     input_path: '%pathname%/Frame.io Transfer.app'
     requirement: identifier "com.frameio.transfer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6D429SHX3Y"
+
+- Processor: Versioner
+  Arguments:
+    input_plist_path: '%pathname%/Frame.io Transfer.app/Contents/Info.plist'
+    plist_version_key: CFBundleShortVersionString

--- a/FrameIO/FrameIOTransfer.pkg.recipe.yaml
+++ b/FrameIO/FrameIOTransfer.pkg.recipe.yaml
@@ -10,4 +10,4 @@ Input:
 Process:
 - Processor: AppPkgCreator
   Arguments:
-    pkg_path: '%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg'
+    app_path: '%pathname%/Frame.io Transfer.app'


### PR DESCRIPTION
This pull request fixes the pattern matching for the FrameIOTransfer download recipe, allowing both the download and pkg recipes to work.

Verbose run output:

```
% autopkg run -vvq FrameIOTransfer.download.recipe.yaml FrameIOTransfer.pkg.recipe.yaml 
Processing FrameIOTransfer.download.recipe.yaml...
WARNING: FrameIOTransfer.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://transferapp\\.frame\\.io/Frame\\.io-Transfer/[a-f0-9]+/latest/darwin/x64/Frame\\.io\\+Transfer\\.dmg)"',
           'url': 'https://frame.io/transfer'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg
{'Output': {'match': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader
{'Input': {'filename': 'FrameIO Transfer.dmg',
           'url': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                        'Transfer.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                         'Transfer.dmg/Frame.io Transfer.app',
           'requirement': 'identifier "com.frameio.transfer" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6D429SHX3Y"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.YUtM3Y/Frame.io Transfer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YUtM3Y/Frame.io Transfer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YUtM3Y/Frame.io Transfer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                               'Transfer.dmg/Frame.io '
                               'Transfer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
Versioner: Found version 1.5.0 in file ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg/Frame.io Transfer.app/Contents/Info.plist
{'Output': {'version': '1.5.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/receipts/FrameIOTransfer.download.recipe-receipt-20241224-112400.plist
Processing FrameIOTransfer.pkg.recipe.yaml...
WARNING: FrameIOTransfer.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://transferapp\\.frame\\.io/Frame\\.io-Transfer/[a-f0-9]+/latest/darwin/x64/Frame\\.io\\+Transfer\\.dmg)"',
           'url': 'https://frame.io/transfer'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg
{'Output': {'match': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader
{'Input': {'filename': 'Frame IO Transfer.dmg',
           'url': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                        'IO Transfer.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                         'IO Transfer.dmg/Frame.io Transfer.app',
           'requirement': 'identifier "com.frameio.transfer" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6D429SHX3Y"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.YotkEj/Frame.io Transfer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YotkEj/Frame.io Transfer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YotkEj/Frame.io Transfer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                               'IO Transfer.dmg/Frame.io '
                               'Transfer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
Versioner: Found version 1.5.0 in file ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg/Frame.io Transfer.app/Contents/Info.plist
{'Output': {'version': '1.5.0'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                       'IO Transfer.dmg/Frame.io Transfer.app',
           'version': '1.5.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
AppPkgCreator: BundleID: com.frameio.transfer
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/Frame.io Transfer-1.5.0.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.5.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/receipts/FrameIOTransfer.pkg.recipe-receipt-20241224-112403.plist

Nothing downloaded, packaged or imported.
✔ FrameIO % rm -rf "~/Library/AutoPkg/Cache/"     
✔ FrameIO % autopkg run -vvq FrameIOTransfer.download.recipe.yaml FrameIOTransfer.pkg.recipe.yaml
Processing FrameIOTransfer.download.recipe.yaml...
WARNING: FrameIOTransfer.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://transferapp\\.frame\\.io/Frame\\.io-Transfer/[a-f0-9]+/latest/darwin/x64/Frame\\.io\\+Transfer\\.dmg)"',
           'url': 'https://frame.io/transfer'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg
{'Output': {'match': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader
{'Input': {'filename': 'FrameIO Transfer.dmg',
           'url': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 20:15:52 GMT
URLDownloader: Storing new ETag header: "8b562fa524d34efd3ee9de5f0a0fbbf2-14"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
{'Output': {'download_changed': True,
            'etag': '"8b562fa524d34efd3ee9de5f0a0fbbf2-14"',
            'last_modified': 'Wed, 11 Dec 2024 20:15:52 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                        'Transfer.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                                                                        'Transfer.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                         'Transfer.dmg/Frame.io Transfer.app',
           'requirement': 'identifier "com.frameio.transfer" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6D429SHX3Y"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PR6zNQ/Frame.io Transfer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PR6zNQ/Frame.io Transfer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PR6zNQ/Frame.io Transfer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO '
                               'Transfer.dmg/Frame.io '
                               'Transfer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg
Versioner: Found version 1.5.0 in file ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg/Frame.io Transfer.app/Contents/Info.plist
{'Output': {'version': '1.5.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/receipts/FrameIOTransfer.download.recipe-receipt-20241224-112422.plist
Processing FrameIOTransfer.pkg.recipe.yaml...
WARNING: FrameIOTransfer.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://transferapp\\.frame\\.io/Frame\\.io-Transfer/[a-f0-9]+/latest/darwin/x64/Frame\\.io\\+Transfer\\.dmg)"',
           'url': 'https://frame.io/transfer'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg
{'Output': {'match': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader
{'Input': {'filename': 'Frame IO Transfer.dmg',
           'url': 'https://transferapp.frame.io/Frame.io-Transfer/6ab0c27d61d7cf8793b0357e6533ed81/latest/darwin/x64/Frame.io+Transfer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 20:15:52 GMT
URLDownloader: Storing new ETag header: "8b562fa524d34efd3ee9de5f0a0fbbf2-14"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
{'Output': {'download_changed': True,
            'etag': '"8b562fa524d34efd3ee9de5f0a0fbbf2-14"',
            'last_modified': 'Wed, 11 Dec 2024 20:15:52 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                        'IO Transfer.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                                                                        'IO '
                                                                        'Transfer.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                         'IO Transfer.dmg/Frame.io Transfer.app',
           'requirement': 'identifier "com.frameio.transfer" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6D429SHX3Y"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PMLF72/Frame.io Transfer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PMLF72/Frame.io Transfer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PMLF72/Frame.io Transfer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                               'IO Transfer.dmg/Frame.io '
                               'Transfer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
Versioner: Found version 1.5.0 in file ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg/Frame.io Transfer.app/Contents/Info.plist
{'Output': {'version': '1.5.0'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame '
                       'IO Transfer.dmg/Frame.io Transfer.app',
           'version': '1.5.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg
AppPkgCreator: BundleID: com.frameio.transfer
AppPkgCreator: Copied /private/tmp/dmg.RmPHJf/Frame.io Transfer.app to ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/payload/Applications/Frame.io Transfer.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.frameio.transfer',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/Frame.io '
                                                                    'Transfer-1.5.0.pkg',
                                                        'version': '1.5.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.5.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/receipts/FrameIOTransfer.pkg.recipe-receipt-20241224-112438.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.download.frameiotransfer/downloads/FrameIO Transfer.dmg  
    ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/downloads/Frame IO Transfer.dmg      

The following packages were built:
    Identifier            Version  Pkg Path                                                                                                          
    ----------            -------  --------                                                                                                          
    com.frameio.transfer  1.5.0    ~/Library/AutoPkg/Cache/com.github.markkenny.autopkg.pkg.frameiotransfer/Frame.io Transfer-1.5.0.pkg
```
