### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/CiscoWebex/CiscoWebex-UNIVERSAL.pkg.recipe.yaml
+++ b/CiscoWebex/CiscoWebex-UNIVERSAL.pkg.recipe.yaml
@@ -37,7 +37,6 @@ Process:
             path: Applications/%bundle_name%.app
             user: root
         id: "%bundle_id%.Intel"
-        options: purge_ds_store
         pkgname: "%bundle_name%-Intel-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/Intel"
         version: "%bundle_version%"
@@ -70,7 +69,6 @@ Process:
             path: Applications/%bundle_name%.app
             user: root
         id: "%bundle_id%.Silicon"
-        options: purge_ds_store
         pkgname: "%bundle_name%-Silicon-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/Silicon"
         version: "%bundle_version%"
@@ -134,7 +132,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%bundle_id%.universal"
-        options: purge_ds_store
         pkgname: "%bundle_name%-Universal-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/universal/root"
         scripts: "%RECIPE_CACHE_DIR%/universal/scripts"

--- a/Microsoft DotNet/DotNet 8 SDK-Universal.pkg.recipe.yaml
+++ b/Microsoft DotNet/DotNet 8 SDK-Universal.pkg.recipe.yaml
@@ -52,14 +52,14 @@ Process:
   Arguments:
     file_content: |
       #!/bin/bash
-      
+
       # Determine working directory
       installDir=$(dirname $0)
-      
+
       # Identify installer package names
       Intel_package="%NAME%-INTEL-%version%.pkg"
       Apple_Silicon_package="%NAME%-ARM-%version%.pkg"
-      
+
       # Determine if this Mac has an Intel or Apple Silicon processor
       processor=$( /usr/bin/arch | grep -o "arm64")
       if [[ -n "$processor" ]]; then
@@ -67,7 +67,7 @@ Process:
       else
       /usr/sbin/installer -pkg "$Intel_package" -target "$3"
       fi
-      
+
       exit 0"
     file_mode: "0755"
     file_path: "%RECIPE_CACHE_DIR%/Universal/scripts/preinstall"
@@ -76,13 +76,12 @@ Process:
   Arguments:
     pkg_request:
       id: com.omnicom-group.dotnet8sdk-universal
-      options: purge_ds_store
       pkgname: "%NAME%-Universal-%version%"
       scripts: "%RECIPE_CACHE_DIR%/Universal/scripts"
       version: "%version%"
 
 - Processor: PathDeleter
   Arguments:
-    path_list: 
+    path_list:
     - '%RECIPE_CACHE_DIR%/unpacked'
     - '%RECIPE_CACHE_DIR%/Universal'

--- a/Microsoft DotNet/DotNet 9 SDK-Universal.pkg.recipe.yaml
+++ b/Microsoft DotNet/DotNet 9 SDK-Universal.pkg.recipe.yaml
@@ -52,14 +52,14 @@ Process:
   Arguments:
     file_content: |
       #!/bin/bash
-      
+
       # Determine working directory
       installDir=$(dirname $0)
-      
+
       # Identify installer package names
       Intel_package="%NAME%-INTEL-%version%.pkg"
       Apple_Silicon_package="%NAME%-ARM-%version%.pkg"
-      
+
       # Determine if this Mac has an Intel or Apple Silicon processor
       processor=$( /usr/bin/arch | grep -o "arm64")
       if [[ -n "$processor" ]]; then
@@ -67,7 +67,7 @@ Process:
       else
       /usr/sbin/installer -pkg "$Intel_package" -target "$3"
       fi
-      
+
       exit 0"
     file_mode: "0755"
     file_path: "%RECIPE_CACHE_DIR%/Universal/scripts/preinstall"
@@ -76,13 +76,12 @@ Process:
   Arguments:
     pkg_request:
       id: com.omnicom-group.dotnet8sdk-universal
-      options: purge_ds_store
       pkgname: "%NAME%-Universal-%version%"
       scripts: "%RECIPE_CACHE_DIR%/Universal/scripts"
       version: "%version%"
 
 - Processor: PathDeleter
   Arguments:
-    path_list: 
+    path_list:
     - '%RECIPE_CACHE_DIR%/unpacked'
     - '%RECIPE_CACHE_DIR%/Universal'

--- a/OpenWebStart/OpenWebStart.pkg.recipe.yaml
+++ b/OpenWebStart/OpenWebStart.pkg.recipe.yaml
@@ -34,7 +34,6 @@ Process:
         path: private/tmp
         user: root
       id: com.github.karakun.openwebstart
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%-%ARCH%-%version%'
       scripts: scripts

--- a/Sketchup/SketchUp2025.pkg.recipe.yaml
+++ b/Sketchup/SketchUp2025.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             user: root
             group: admin
         id: com.sketchup.%NAME%-%version%
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%pkgroot%'
         version: '%version%'


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and remove the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._