### PR TITLE
Add quotes to expected authorities list

### DIFF
--- a/LucidLink/LucidLink.download.recipe.yaml
+++ b/LucidLink/LucidLink.download.recipe.yaml
@@ -16,5 +16,5 @@ Process:
       input_path: "%pathname%"
       expected_authority_names:
         - "Developer ID Installer: LucidLink Corp. (Y4KMJPU2B4)"
-        - Developer ID Certification Authority
-        - Apple Root CA
+        - "Developer ID Certification Authority"
+        - "Apple Root CA"


### PR DESCRIPTION
Since the first item in the list is quoted, the YAML parser expects the remaining items to also be quoted. This PR adds quotes to the remaining items.