### PR TITLE
Added explicit app_path to AppPkgCreator

### DIFF
--- a/Extensis/MonotypeConnect.pkg.recipe.yaml
+++ b/Extensis/MonotypeConnect.pkg.recipe.yaml
@@ -9,3 +9,5 @@ Input:
 
 Process:
 - Processor: AppPkgCreator
+  Arguments:
+    app_path: "%pathname%/Monotype Connect.app"


### PR DESCRIPTION
One change was made to MonotypeConnect.pkg.recipe.yaml:

Added explicit app_path to AppPkgCreator

The DMG contains both Extensis Connect.app (an alias) and Monotype Connect.app. Without an explicit app_path, AppPkgCreator globs *.app in the DMG root and picks Extensis Connect.app first alphabetically, resulting in the wrong app being packaged. Setting app_path explicitly to %pathname%/Monotype Connect.app ensures the correct app is always packaged.