### PR TITLE
Updated path-removed space in name

### DIFF
--- a/Insta360/Insta360-Studio.pkg.recipe.yaml
+++ b/Insta360/Insta360-Studio.pkg.recipe.yaml
@@ -39,4 +39,4 @@ Process:
       path_list:
         - "%RECIPE_CACHE_DIR%/unpacked"
         - "%RECIPE_CACHE_DIR%/Applications"
-        - "%RECIPE_CACHE_DIR%/Insta360 Studio"
+        - "%RECIPE_CACHE_DIR%/Insta360Studio"


### PR DESCRIPTION
Recipe was failing due to the path deleter having a space in the name. 